### PR TITLE
Change ROCK name to be the same as the resources in charmcraft

### DIFF
--- a/githubactionsexporter_rock/rockcraft.yaml
+++ b/githubactionsexporter_rock/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: githubactionsexporter
-summary: githubactionsexporter rock
+name: github-actions-exporter
+summary: github-actions-exporter rock
 description: GitHub Actions Exporter OCI image for the GitHub Actions Exporter charm
 version: "1.0"
 base: ubuntu:22.04

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,4 +6,4 @@
 
 def pytest_addoption(parser):
     """Parse additional pytest options."""
-    parser.addoption("--githubactionsexporter-image", action="store")
+    parser.addoption("--github-actions-exporter-image", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,7 +85,7 @@ async def gh_app_fixture(
     )
 
     resources = {
-        "github-actions-exporter-image": pytestconfig.getoption("--githubactionsexporter-image"),
+        "github-actions-exporter-image": pytestconfig.getoption("--github-actions-exporter-image"),
     }
     charm = await ops_test.build_charm(".")
     async with ops_test.fast_forward():


### PR DESCRIPTION
This is needed as coded here:
https://github.com/canonical/operator-workflows/blob/main/.github/workflows/publish_charm.yaml#L169