### PR TITLE
Fix prometheus_scrape integration by adding prometheus_alert_rules

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Prometheus Scrape Library.
 
@@ -17,13 +17,6 @@ provide a scrape target for Prometheus.
 
 Source code can be found on GitHub at:
  https://github.com/canonical/prometheus-k8s-operator/tree/main/lib/charms/prometheus_k8s
-
-## Dependencies
-
-Using this library requires you to fetch the juju_topology library from
-[observability-libs](https://charmhub.io/observability-libs/libraries/juju_topology).
-
-`charmcraft fetch-lib charms.observability_libs.v0.juju_topology`
 
 ## Provider Library Usage
 
@@ -343,12 +336,11 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
-from urllib.request import urlopen
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
+from cosl.rules import AlertRules
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -370,7 +362,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 36
+LIBPATCH = 42
+
+PYDEPS = ["cosl"]
 
 logger = logging.getLogger(__name__)
 
@@ -391,6 +385,7 @@ ALLOWED_KEYS = {
     "scheme",
     "basic_auth",
     "tls_config",
+    "authorization",
 }
 DEFAULT_JOB = {
     "metrics_path": "/metrics",
@@ -601,15 +596,22 @@ class PrometheusConfig:
         # Create a mapping from paths to netlocs
         # Group alertmanager targets into a dictionary of lists:
         # {path: [netloc1, netloc2]}
-        paths = defaultdict(list)  # type: Dict[str, List[str]]
+        paths = defaultdict(list)  # type: Dict[Tuple[str, str], List[str]]
         for parsed in map(urlparse, sanitized):
             path = parsed.path or "/"
-            paths[path].append(parsed.netloc)
+            paths[(parsed.scheme, path)].append(parsed.netloc)
 
         return {
             "alertmanagers": [
-                {"path_prefix": path_prefix, "static_configs": [{"targets": netlocs}]}
-                for path_prefix, netlocs in paths.items()
+                {
+                    # For https we still do not render a `tls_config` section because
+                    # certs are expected to be made available by the charm via the
+                    # `update-ca-certificates` mechanism.
+                    "scheme": scheme,
+                    "path_prefix": path_prefix,
+                    "static_configs": [{"targets": netlocs}],
+                }
+                for (scheme, path_prefix), netlocs in paths.items()
             ]
         }
 
@@ -828,206 +830,6 @@ def _is_single_alert_rule_format(rules_dict: dict) -> bool:
     """
     # one alert rule per file
     return set(rules_dict) >= {"alert", "expr"}
-
-
-class AlertRules:
-    """Utility class for amalgamating prometheus alert rule files and injecting juju topology.
-
-    An `AlertRules` object supports aggregating alert rules from files and directories in both
-    official and single rule file formats using the `add_path()` method. All the alert rules
-    read are annotated with Juju topology labels and amalgamated into a single data structure
-    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
-    easily dumped into JSON format and exchanged over relation data. The dictionary can also
-    be dumped into YAML format and written directly into an alert rules file that is read by
-    Prometheus. Note that multiple `AlertRules` objects must not be written into the same file,
-    since Prometheus allows only a single list of alert rule groups per alert rules file.
-
-    The official Prometheus format is a YAML file conforming to the Prometheus documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    # This class uses the following terminology for the various parts of a rule file:
-    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
-    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
-    #   of dictionaries that have the "name" and "rules" keys.
-    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
-    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
-    #   the "alert" and "expr" keys.
-    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
-
-    def __init__(self, topology: Optional[JujuTopology] = None):
-        """Build and alert rule object.
-
-        Args:
-            topology: an optional `JujuTopology` instance that is used to annotate all alert rules.
-        """
-        self.topology = topology
-        self.tool = CosTool(None)
-        self.alert_groups = []  # type: List[dict]
-
-    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
-        """Read a rules file from path, injecting juju topology.
-
-        Args:
-            root_path: full path to the root rules folder (used only for generating group name)
-            file_path: full path to a *.rule file.
-
-        Returns:
-            A list of dictionaries representing the rules file, if file is valid (the structure is
-            formed by `yaml.safe_load` of the file); an empty list otherwise.
-        """
-        with file_path.open() as rf:
-            # Load a list of rules from file then add labels and filters
-            try:
-                rule_file = yaml.safe_load(rf)
-
-            except Exception as e:
-                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
-                return []
-
-            if not rule_file:
-                logger.warning("Empty rules file: %s", file_path.name)
-                return []
-            if not isinstance(rule_file, dict):
-                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
-                return []
-            if _is_official_alert_rule_format(rule_file):
-                alert_groups = rule_file["groups"]
-            elif _is_single_alert_rule_format(rule_file):
-                # convert to list of alert groups
-                # group name is made up from the file name
-                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
-            else:
-                # invalid/unsupported
-                logger.error("Invalid rules file: %s", file_path.name)
-                return []
-
-            # update rules with additional metadata
-            for alert_group in alert_groups:
-                # update group name with topology and sub-path
-                alert_group["name"] = self._group_name(
-                    str(root_path),
-                    str(file_path),
-                    alert_group["name"],
-                )
-
-                # add "juju_" topology labels
-                for alert_rule in alert_group["rules"]:
-                    if "labels" not in alert_rule:
-                        alert_rule["labels"] = {}
-
-                    if self.topology:
-                        alert_rule["labels"].update(self.topology.label_matcher_dict)
-                        # insert juju topology filters into a prometheus alert rule
-                        alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
-                            self.topology.label_matcher_dict,
-                        )
-
-            return alert_groups
-
-    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
-        """Generate group name from path and topology.
-
-        The group name is made up of the relative path between the root dir_path, the file path,
-        and topology identifier.
-
-        Args:
-            root_path: path to the root rules dir.
-            file_path: path to rule file.
-            group_name: original group name to keep as part of the new augmented group name
-
-        Returns:
-            New group name, augmented by juju topology and relative path.
-        """
-        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
-        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
-
-        # Generate group name:
-        #  - name, from juju topology
-        #  - suffix, from the relative path of the rule file;
-        group_name_parts = [self.topology.identifier] if self.topology else []
-        group_name_parts.extend([rel_path, group_name, "alerts"])
-        # filter to remove empty strings
-        return "_".join(filter(None, group_name_parts))
-
-    @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
-        """Helper function for getting all files in a directory that have a matching suffix.
-
-        Args:
-            dir_path: path to the directory to glob from.
-            suffixes: list of suffixes to include in the glob (items should begin with a period).
-            recursive: a flag indicating whether a glob is recursive (nested) or not.
-
-        Returns:
-            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
-        """
-        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
-        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
-
-    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
-        """Read all rule files in a directory.
-
-        All rules from files for the same directory are loaded into a single
-        group. The generated name of this group includes juju topology.
-        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-        Args:
-            dir_path: directory containing *.rule files (alert rules without groups).
-            recursive: flag indicating whether to scan for rule files recursively.
-
-        Returns:
-            a list of dictionaries representing prometheus alert rule groups, each dictionary
-            representing an alert group (structure determined by `yaml.safe_load`).
-        """
-        alert_groups = []  # type: List[dict]
-
-        # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(
-            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
-        ):
-            alert_groups_from_file = self._from_file(dir_path, file_path)
-            if alert_groups_from_file:
-                logger.debug("Reading alert rule from %s", file_path)
-                alert_groups.extend(alert_groups_from_file)
-
-        return alert_groups
-
-    def add_path(self, path: str, *, recursive: bool = False) -> None:
-        """Add rules from a dir path.
-
-        All rules from files are aggregated into a data structure representing a single rule file.
-        All group names are augmented with juju topology.
-
-        Args:
-            path: either a rules file or a dir of rules files.
-            recursive: whether to read files recursively or not (no impact if `path` is a file).
-
-        Returns:
-            True if path was added else False.
-        """
-        path = Path(path)  # type: Path
-        if path.is_dir():
-            self.alert_groups.extend(self._from_dir(path, recursive))
-        elif path.is_file():
-            self.alert_groups.extend(self._from_file(path.parent, path))
-        else:
-            logger.debug("Alert rules path does not exist: %s", path)
-
-    def as_dict(self) -> dict:
-        """Return standard alert rules file in dict representation.
-
-        Returns:
-            a dictionary containing a single list of alert rule groups.
-            The list of alert rule groups is provided as value of the
-            "groups" dictionary key.
-        """
-        return {"groups": self.alert_groups} if self.alert_groups else {}
 
 
 class TargetsChangedEvent(EventBase):
@@ -1320,7 +1122,7 @@ class MetricsEndpointConsumer(Object):
                         # Inject topology and put it back in the list
                         rule["expr"] = self._tool.inject_label_matchers(
                             re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
-                            topology.label_matcher_dict,
+                            topology.alert_expression_dict,
                         )
                     except KeyError:
                         # Some required JujuTopology key is missing. Just move on.
@@ -1352,29 +1154,31 @@ class MetricsEndpointConsumer(Object):
         if not relation.units:
             return []
 
-        scrape_jobs = json.loads(relation.data[relation.app].get("scrape_jobs", "[]"))
+        scrape_configs = json.loads(relation.data[relation.app].get("scrape_jobs", "[]"))
 
-        if not scrape_jobs:
+        if not scrape_configs:
             return []
 
         scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata", "{}"))
 
         if not scrape_metadata:
-            return scrape_jobs
+            return scrape_configs
 
         topology = JujuTopology.from_dict(scrape_metadata)
 
         job_name_prefix = "juju_{}_prometheus_scrape".format(topology.identifier)
-        scrape_jobs = PrometheusConfig.prefix_job_names(scrape_jobs, job_name_prefix)
-        scrape_jobs = PrometheusConfig.sanitize_scrape_configs(scrape_jobs)
+        scrape_configs = PrometheusConfig.prefix_job_names(scrape_configs, job_name_prefix)
+        scrape_configs = PrometheusConfig.sanitize_scrape_configs(scrape_configs)
 
         hosts = self._relation_hosts(relation)
 
-        scrape_jobs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            scrape_jobs, hosts, topology
+        scrape_configs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            scrape_configs, hosts, topology
         )
 
-        return scrape_jobs
+        # For https scrape targets we still do not render a `tls_config` section because certs
+        # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
+        return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
         """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
@@ -1721,7 +1525,7 @@ class MetricsEndpointProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(topology=self.topology)
+        alert_rules = AlertRules(query_type="promql", topology=self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -1792,10 +1596,10 @@ class MetricsEndpointProvider(Object):
            A list of dictionaries, where each dictionary specifies a
            single scrape job for Prometheus.
         """
-        jobs = self._jobs if self._jobs else [DEFAULT_JOB]
+        jobs = self._jobs or []
         if callable(self._lookaside_jobs):
-            return jobs + PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs())
-        return jobs
+            jobs.extend(PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs()))
+        return jobs or [DEFAULT_JOB]
 
     @property
     def _scrape_metadata(self) -> dict:
@@ -1868,7 +1672,7 @@ class PrometheusRulesProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules()
+        alert_rules = AlertRules(query_type="promql")
         alert_rules.add_path(self.dir_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -2248,16 +2052,7 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        label_re = re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
 
-        try:
-            with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:
-                data = resp.read().decode("utf-8").splitlines()
-                for metric in data:
-                    for match in label_re.finditer(metric):
-                        extra_info[match.group("label")] = match.group("value")
-        except (HTTPError, URLError, OSError, ConnectionResetError, Exception) as e:
-            logger.debug("Could not scrape target: %s", e)
         return extra_info
 
     @property

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@ name: github-actions-exporter
 display-name: GitHub Actions Exporter
 summary: GitHub Actions Exporter
 description: Collects metrics from GitHub Actions.
-docs: ""
+docs: "https://github.com/canonical/github-actions-exporter-operator/"
 issues: https://github.com/canonical/github-actions-exporter-operator/issues
 maintainers:
   - launchpad.net/~canonical-is-devops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-ops>=2.0.0
-juju==2.9.42.4
-jsonschema == 4.17.3
-pydantic==1.10.10
+jsonschema ==4.19.0
+ops ==2.6.0
+pydantic ==1.10.12
+requests == 2.31.0
+cosl ==0.0.7

--- a/src/prometheus_alert_rules/github_missing.rule
+++ b/src/prometheus_alert_rules/github_missing.rule
@@ -1,0 +1,8 @@
+alert: GitHubActionsDashboardTargetMissing
+expr: up == 0
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "GitHub Actions Dashboard target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,4 @@
 def pytest_addoption(parser):
     """Parse additional pytest options."""
     parser.addoption("--github-actions-exporter-image", action="store")
+    parser.addoption("--charm-file", action="store", help="Charm file to be deployed")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,10 +87,10 @@ async def gh_app_fixture(
     resources = {
         "github-actions-exporter-image": pytestconfig.getoption("--github-actions-exporter-image"),
     }
-    charm = await ops_test.build_charm(".")
+    charm = pytestconfig.getoption("--charm-file")
     async with ops_test.fast_forward():
         application = await ops_test.model.deploy(
-            charm, resources=resources, application_name=app_name, series="focal"
+            f"./{charm}", resources=resources, application_name=app_name, series="focal"
         )
         await dependencies
     # Add required relations, mypy has difficulty with WaitingStatus

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
+    cosl
     coverage[toml]
     pytest
     -r{toxinidir}/requirements.txt
@@ -141,6 +142,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    cosl
     juju==2.9.42.4
     pytest
     pytest-asyncio


### PR DESCRIPTION
### Overview

If there is no prometheus_alert_rules the charm fails with "Invalid Prometheus alert rules folder at /var/lib/juju/agents/unit-github-actions-exporter-0/charm/src/prometheus_alert_rules: directory does not exist"
This PR fixes it, update the library and add a temporary docs field to charmcraft run as expected.

### Rationale

This way the charm can integrate with the Prometheus charm as expected.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

There is no src-docs for this charm.
There is no charmhub documentation for this charm.
