### PR TITLE
fix setuptools breaking dep issue

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,6 +10,8 @@ bases:
       channel: "22.04"
 parts:
   charm:
+    charm-binary-python-packages:
+      - setuptools
     build-packages:
       - libffi-dev  # for cffi
       - libssl-dev  # for cryptography


### PR DESCRIPTION
The recent release of setuptools is not compatible with dogpile lib which breaks charmcraft because it tries to build everything from source.
Just use binary version of these tools.