### PR TITLE
fix: revert charm binary packages (fixed upstream)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,6 +10,11 @@ bases:
       channel: "22.04"
 parts:
   charm:
+    build-snaps:
+      - rustup
+    override-build: |
+      rustup default stable
+      craftctl default
     build-packages:
       - libffi-dev  # for cffi
       - libssl-dev  # for cryptography

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,8 +10,6 @@ bases:
       channel: "22.04"
 parts:
   charm:
-    charm-binary-python-packages:
-      - setuptools
     build-packages:
       - libffi-dev  # for cffi
       - libssl-dev  # for cryptography


### PR DESCRIPTION
Reverts charmcraft.yaml's
```
    charm-binary-python-packages:
      - setuptools
```
which was used to fix upstream setuptools backwards-incompatible 72.0 release.
This has been fixed upstream yesterday: https://github.com/pypa/setuptools/commit/441799f8b45a1a01c608db49333403db1b0d7100. 

Rust toolchain snaps had to be used because one of the dependencies use python rust bindings. The charmcraft provided rust is an older version which is not compatible with the rust version provided (`Error: Either upgrade to rustc 1.76 or newer, or use ...`. 
Since we try to build everything from source if possible, switch binary downloads to rustc toolchain snap install.