### PR TITLE
chores: fix tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
@@ -48,7 +48,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
This PR removes the version requirement for flake8.