### PR TITLE
fix: change checks and configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,10 +10,8 @@ options:
     type: string
     description: |
       The GitHub API Access Token used to collect the Action Billing metrics.
-    default: "default"
   github_org:
     type: string
     description: |
       GitHub Organization from which the Action Billing metrics will be
       collected.
-    default: "default"

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,6 +117,7 @@ class GithubActionsExporterCharm(CharmBase):
             "services": {
                 "github-actions-exporter": {
                     "override": "replace",
+                    "on-check-failure": {gh_exporter.CHECK_READY_NAME: "restart"},
                     "summary": "github-actions-exporter",
                     "startup": "enabled",
                     "user": GITHUB_USER,

--- a/src/github_actions_exporter.py
+++ b/src/github_actions_exporter.py
@@ -27,6 +27,7 @@ def check_ready() -> Dict:
     check.override = "replace"
     check.level = "ready"
     check.tcp = {"port": GITHUB_METRICS_PORT}
+    check.threshold = 2
     # _CheckDict cannot be imported
     return check.to_dict()  # type: ignore
 
@@ -56,7 +57,7 @@ def is_configuration_valid(state: CharmState) -> bool:
     Returns:
         True if they are all set
     """
-    return all([state.github_webhook_token, state.github_api_token, state.github_org])
+    return state.github_webhook_token or all([state.github_api_token, state.github_org])
 
 
 def version(container: Container) -> str:

--- a/src/prometheus_alert_rules/github_missing.rule
+++ b/src/prometheus_alert_rules/github_missing.rule
@@ -2,7 +2,7 @@ alert: GitHubActionsDashboardTargetMissing
 expr: up == 0
 for: 0m
 labels:
-  severity: critical
+  severity: warning
 annotations:
   summary: Prometheus target missing (instance {{ $labels.instance }})
   description: "GitHub Actions Dashboard target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -100,8 +100,6 @@ class TestCharm(unittest.TestCase):
         updated_plan = self.harness.get_container_pebble_plan("github-actions-exporter").to_dict()
         updated_plan_env = updated_plan["services"]["github-actions-exporter"]["environment"]
         self.assertEqual("default", updated_plan_env["GITHUB_WEBHOOK_TOKEN"])
-        self.assertEqual("default", updated_plan_env["GITHUB_API_TOKEN"])
-        self.assertEqual("default", updated_plan_env["GITHUB_ORG"])
 
     @patch.object(ops.Container, "exec")
     def test_valid_webhook_token(self, mock_container_exec):


### PR DESCRIPTION
This PR:
- change pebble check threshold from 3 (default) to 2
- change pebble plan for restart if check fails
- decrease alert rule from critical to warning
- change configuration to accept empty values so billing wont be checked by the exporter
- remove default values for org and API token.