### PR TITLE
fix: remove min length and change docstring

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -37,8 +37,8 @@ class GithubActionsExporterConfig(BaseModel):  # pylint: disable=too-few-public-
         github_webhook_token: github_webhook_token config.
     """
 
-    github_api_token: str = Field(None, min_length=1)
-    github_org: str = Field(None, min_length=1)
+    github_api_token: str = Field(None)
+    github_org: str = Field(None)
     github_webhook_token: str = Field(..., min_length=1)
 
     class Config:  # pylint: disable=too-few-public-methods

--- a/src/github_actions_exporter.py
+++ b/src/github_actions_exporter.py
@@ -55,7 +55,8 @@ def is_configuration_valid(state: CharmState) -> bool:
         state: The state of the charm.
 
     Returns:
-        True if they are all set
+        True if all configs are set, github_webhook_token is set or
+            github_api_token and github_org are set.
     """
     return state.github_webhook_token or all([state.github_api_token, state.github_org])
 


### PR DESCRIPTION
This is a follow-up for the https://github.com/canonical/github-actions-exporter-operator/pull/79.

Removes min_length from charm_state and update docstring as noted by @cbartz (thanks).